### PR TITLE
Fixed gems 1’s compilation errors with newer cc

### DIFF
--- a/gems/2DClip/bio.c
+++ b/gems/2DClip/bio.c
@@ -141,7 +141,7 @@ int	no;
  *	delete contour(s) from the list with id
  *	no
  */
-del_contour(no)
+void del_contour(no)
 int	no;
 {
 	CONTOUR	*cp, *cpp;

--- a/gems/2DClip/clip.c
+++ b/gems/2DClip/clip.c
@@ -6,6 +6,8 @@
 #include	"GraphicsGems.h"
 #include	"line.h"
 
+void clip(CONTOUR	*p, SEGMENT	*l);
+
 /*
  * vis_vector
  *
@@ -16,7 +18,7 @@
  *	xf, yf	from coordinates of vector to be drawn
  *	xt, yt	to coordinates of vector to be drawn
  */
-vis_vector(xf, yf, xt, yt)
+void vis_vector(xf, yf, xt, yt)
 long	xf, yf, xt, yt;
 {
 	SEGMENT	l;
@@ -41,7 +43,7 @@ long	xf, yf, xt, yt;
  *	p	pointer to polygon
  *	l	pointer to line segment
  */
-clip(p, l)
+void clip(p, l)
 CONTOUR	*p;
 SEGMENT	*l;
 {

--- a/gems/AAPolyScan.c
+++ b/gems/AAPolyScan.c
@@ -65,7 +65,7 @@ extern void renderPixel(/* int x, y, Vertex *V,
 /*
  * Render shaded polygon
  */
-drawPolygon(polygon, numVertex, object)
+void drawPolygon(polygon, numVertex, object)
 	Vertex	polygon[];		/*clockwise clipped vertex list */
 	int	numVertex;			/*number of vertices in polygon */
 

--- a/gems/ConcaveScan.c
+++ b/gems/ConcaveScan.c
@@ -48,9 +48,11 @@ static Point2 *pt;		/* vertices */
 static int nact;		/* number of active edges */
 static Edge *active;		/* active edge list:edges crossing scanline y */
 
+static void cdelete(int i);
+static void cinsert(int i, int y);
 int compare_ind(), compare_active();
 
-concave(nvert, point, win, spanproc)
+void concave(nvert, point, win, spanproc)
 int nvert;			/* number of vertices */
 Point2 *point;			/* vertices of polygon */
 Window *win;			/* screen clipping window */
@@ -117,7 +119,7 @@ void (*spanproc)();		/* called for each span of pixels */
     }
 }
 
-static cdelete(i)		/* remove edge i from active list */
+static void cdelete(i)		/* remove edge i from active list */
 int i;
 {
     int j;
@@ -128,7 +130,7 @@ int i;
     bcopy(&active[j+1], &active[j], (nact-j)*sizeof active[0]);
 }
 
-static cinsert(i, y)		/* append edge i to end of active list */
+static void cinsert(i, y)		/* append edge i to end of active list */
 int i, y;
 {
     int j;

--- a/gems/DigitalLine.c
+++ b/gems/DigitalLine.c
@@ -14,7 +14,7 @@
 
 #include "GraphicsGems.h"
 
-digline(x1, y1, x2, y2, dotproc)
+void digline(x1, y1, x2, y2, dotproc)
 int x1, y1, x2, y2;
 void (*dotproc)();
 {

--- a/gems/DoubleLine.c
+++ b/gems/DoubleLine.c
@@ -8,7 +8,7 @@ user provides "setpixel()" function for output.
 
 #define swap(a,b)           {a^=b; b^=a; a^=b;}
 #define absolute(i,j,k)     ( (i-j)*(k = ( (i-j)<0 ? -1 : 1)))
-int
+void
 symwuline(a1, b1, a2, b2) int a1, b1, a2, b2;
 {
 	int           dx, dy, incr1, incr2, D, x, y, xend, c, pixels_left;

--- a/gems/FitCurves.c
+++ b/gems/FitCurves.c
@@ -11,7 +11,7 @@ from "Graphics Gems", Academic Press, 1990
 
 #include "GraphicsGems.h"					
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 typedef Point2 *BezierCurve;
@@ -255,7 +255,7 @@ static BezierCurve  GenerateBezier(d, first, last, uPrime, tHat1, tHat2)
     /* (if alpha is 0, you get coincident control points that lead to
      * divide by zero in any subsequent NewtonRaphsonRootFind() call. */
     double segLength = V2DistanceBetween2Points(&d[last], &d[first]);
-    epsilon = 1.0e-6 * segLength;
+    double epsilon = 1.0e-6 * segLength;
     if (alpha_l < epsilon || alpha_r < epsilon)
     {
 		/* fall back on standard (probably inaccurate) formula, and subdivide further if needed. */

--- a/gems/NearestPoint.c
+++ b/gems/NearestPoint.c
@@ -9,7 +9,7 @@ from "Graphics Gems", Academic Press, 1990
  /*	point_on_curve.c	*/		
 									
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include "GraphicsGems.h"
 

--- a/gems/PolyScan/poly_scan.c
+++ b/gems/PolyScan/poly_scan.c
@@ -14,6 +14,11 @@
 #include <math.h>
 #include "poly.h"
 
+static void scanline(int y, Poly_vert *l, Poly_vert *r, Window *win, void (*pixelproc)(), unsigned long mask);
+static incrementalize_y(register double *p1, register double *p2, register double *p, register double *dp, int y, register unsigned long mask);
+static incrementalize_x(register double *p1, register double *p2, register double *p, register double *dp, int x, register unsigned long mask);
+static increment(register double *p, register double *dp, register unsigned long mask);
+
 /*
  * poly_scan: Scan convert a polygon, calling pixelproc at each pixel with an
  * interpolated Poly_vert structure.  Polygon can be clockwise or ccw.
@@ -100,7 +105,7 @@ void (*pixelproc)();		/* procedure called at each pixel */
 
 /* scanline: output scanline by sampling polygon at Y=y+.5 */
 
-static scanline(y, l, r, win, pixelproc, mask)
+static void scanline(y, l, r, win, pixelproc, mask)
 int y;
 unsigned long mask;
 Poly_vert *l, *r;

--- a/gems/PolyScan/scantest.c
+++ b/gems/PolyScan/scantest.c
@@ -16,6 +16,7 @@
 
 #define FRANDOM() ((rand()&32767)/32767.)   /* random number between 0 and 1 */
 
+static void pixelproc(int x, int y, Poly_vert *point);
 void pixelproc();
 
 main(ac, av)

--- a/gems/SeedFill.c
+++ b/gems/SeedFill.c
@@ -43,7 +43,7 @@ typedef struct {short y, xl, xr, dy;} Segment;
  * A 4-connected neighbor is a pixel above, below, left, or right of a pixel.
  */
 
-fill(x, y, win, nv)
+void fill(x, y, win, nv)
 int x, y;	/* seed point */
 Window *win;	/* screen window */
 Pixel nv;	/* new pixel value */

--- a/gems/Sturm/sturm.c
+++ b/gems/Sturm/sturm.c
@@ -197,7 +197,7 @@ numchanges(np, sseq, a)
  * described in sseq to isolate intervals in which roots occur,
  * the roots are returned in the roots array in order of magnitude.
  */
-sbisect(np, sseq, min, max, atmin, atmax, roots)
+void sbisect(np, sseq, min, max, atmin, atmax, roots)
 	int		np;
 	poly	*sseq;
 	double	min, max;


### PR DESCRIPTION
I fixed some compilation errors for gems 1, such that it can be compiled on Mac/Linux using:
- Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
- cc (Ubuntu/Linaro 4.7.3-1ubuntu1) 4.7.3

My changes:
- Added function declarations.
- Added void return type.
- `#include <malloc.h>` => `#include <stdlib.h>`

PS.Since I don't know how to install the Utah Raster Toolkit on Mac/Linux, I haven't tested the AALines example.
