### PR TITLE
Fixed typo and interpolation for odd-sized contextual regions in CLAHE function

### DIFF
--- a/gemsiv/clahe.c
+++ b/gemsiv/clahe.c
@@ -86,7 +86,7 @@ int CLAHE (kz_pixel_t* pImage, unsigned int uiXRes, unsigned int uiYRes,
     if (uiNrX > uiMAX_REG_X) return -1;	   /* # of regions x-direction too large */
     if (uiNrY > uiMAX_REG_Y) return -2;	   /* # of regions y-direction too large */
     if (uiXRes % uiNrX) return -3;	  /* x-resolution no multiple of uiNrX */
-    if (uiYRes & uiNrY) return -4;	  /* y-resolution no multiple of uiNrY */
+    if (uiYRes % uiNrY) return -4;	  /* y-resolution no multiple of uiNrY */
     if (Max >= uiNR_OF_GREY) return -5;	   /* maximum too large */
     if (Min >= Max) return -6;		  /* minimum equal or larger than maximum */
     if (uiNrX < 2 || uiNrY < 2) return -7;/* at least 4 contextual regions required */

--- a/gemsiv/clahe.c
+++ b/gemsiv/clahe.c
@@ -123,7 +123,7 @@ int CLAHE (kz_pixel_t* pImage, unsigned int uiXRes, unsigned int uiYRes,
 	}
 	else {
 	    if (uiY == uiNrY) {				  /* special case: bottom row */
-		uiSubY = uiYSize >> 1;	uiYU = uiNrY-1;	 uiYB = uiYU;
+		uiSubY = uiYSize+1 >> 1;	uiYU = uiNrY-1;	 uiYB = uiYU;
 	    }
 	    else {					  /* default values */
 		uiSubY = uiYSize; uiYU = uiY - 1; uiYB = uiYU + 1;
@@ -135,7 +135,7 @@ int CLAHE (kz_pixel_t* pImage, unsigned int uiXRes, unsigned int uiYRes,
 	    }
 	    else {
 		if (uiX == uiNrX) {			  /* special case: right column */
-		    uiSubX = uiXSize >> 1;  uiXL = uiNrX - 1; uiXR = uiXL;
+		    uiSubX = uiXSize+1 >> 1;  uiXL = uiNrX - 1; uiXR = uiXL;
 		}
 		else {					  /* default values */
 		    uiSubX = uiXSize; uiXL = uiX - 1; uiXR = uiXL + 1;


### PR DESCRIPTION
Hi,
This pull request fixes the following two bugs I've identified two bugs in **clahe.c**.

1. In the check whether the y-resolution is a multiple of the number of regions in y-direction the operand was `&` instead of `%`.

2. The indices at the interpolation step were wrongly calculated in the case when the x- or y-size of the contextual regions was an odd number. This resulted in a systematic shift introducing artifacts to the output result, which can be best illustrated by the following 248 x 248 image
![a](https://cloud.githubusercontent.com/assets/6545356/26687423/f3406812-46ef-11e7-93b8-6e4c0f5f32ce.png)

    processed with 8 contextual regions in each direction resulting in 31 x 31 sized squares. Look for the stepped line at the right border of the image.
    ![b](https://cloud.githubusercontent.com/assets/6545356/26687426/f5d42e56-46ef-11e7-9e21-d859a93b5715.png)

Thank for your kind consideration of my bugfixes. I'm looking forward to hearing from you.

Cheers,
Andrzej